### PR TITLE
Ports orphan cleanup to new API call

### DIFF
--- a/pulp_smash/pulp3/bindings.py
+++ b/pulp_smash/pulp3/bindings.py
@@ -2,6 +2,12 @@ from unittest import TestCase
 from time import sleep
 
 from pulpcore.client.pulpcore import ApiClient, OrphansApi, TaskGroupsApi, TasksApi, TaskGroupsApi
+
+try:
+    from pulpcore.client.pulpcore import OrphansCleanupApi
+except ImportError:  # This is only available in pulpcore 3.14+
+    OrphansCleanupApi = None
+
 from pulp_smash.api import _get_sleep_time
 from pulp_smash.config import get_config
 
@@ -97,5 +103,8 @@ def monitor_task_group(tg_href):
 
 def delete_orphans():
     """Delete orphans through bindings."""
-    response = OrphansApi(pulpcore_client).delete()
+    if OrphansCleanupApi:
+        response = OrphansCleanupApi(pulpcore_client).cleanup({})
+    else:
+        response = OrphansApi(pulpcore_client).delete()
     monitor_task(response.task)


### PR DESCRIPTION
This change attempts to use the new
`POST /pulp/api/v3/orphans/cleanup/` API. It's only available in 3.14+
so there is a fallback implementation to the old style call if the new
one isn't available.

[noissue]