### PR TITLE
Adds pytest and pytest-xdist as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,10 @@ setup(
         "packaging",
         "plumbum",
         "pulpcore-client",
+        "pytest",
+        "pytest-xdist",
         "pyxdg",
         "requests",
-        "pulpcore-client",
         "trustme",
     ],
     entry_points={


### PR DESCRIPTION
These are not used directly in pulp-smash, but pytest-xdist is going to
be used by everyone who uses pulp-smash soon, so let's make it available
everywhere by adding it here.

[noissue]