### PR TITLE
Adds custom-exit-code pytest plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "plumbum",
         "pulpcore-client",
         "pytest",
+        "pytest-custom_exit_code",
         "pytest-xdist",
         "pyxdg",
         "requests",


### PR DESCRIPTION
In some situations pytest may run tests and collect non, e.g. when a
plugin has not added any `parallel` marks. This plugin allows the
`pytest-custom_exit_code` to be added when that's possible and not fail
the CI.

[noissue]